### PR TITLE
[IMP] oauth_provider: get access_token from headers, remove werkzeug.wrappers.BaseResponse

### DIFF
--- a/oauth_provider/controllers/main.py
+++ b/oauth_provider/controllers/main.py
@@ -223,7 +223,7 @@ class OAuth2ProviderController(http.Controller):
 
         # Retrieve needed arguments for oauthlib methods
         uri, http_method, body, headers = self._get_request_information()
-        credentials = {"scope": scope}
+        credentials = {"scope": " ".join(client.scope_ids.mapped("code"))}
 
         # Retrieve the authorization code, if any, to get Odoo's user id
         existing_code = (
@@ -260,7 +260,7 @@ class OAuth2ProviderController(http.Controller):
             credentials=credentials,
         )
 
-        return werkzeug.wrappers.BaseResponse(body, status=status, headers=headers)
+        return werkzeug.Response(body, status=status, headers=headers)
 
     @http.route(
         "/oauth2/tokeninfo", type="http", auth="none", methods=["GET"], website=True
@@ -271,6 +271,10 @@ class OAuth2ProviderController(http.Controller):
         Similar to Google's "tokeninfo" request
         """
         ensure_db()
+        if not access_token:
+            auth_header = http.request.httprequest.headers.get("Authorization", "")
+            if auth_header.startswith("Bearer "):
+                access_token = auth_header[7:]
         token = self._check_access_token(access_token)
         if not token:
             return self._json_response(
@@ -302,6 +306,10 @@ class OAuth2ProviderController(http.Controller):
         Similar to Google's "userinfo" request
         """
         ensure_db()
+        if not access_token:
+            auth_header = http.request.httprequest.headers.get("Authorization", "")
+            if auth_header.startswith("Bearer "):
+                access_token = auth_header[7:]
         token = self._check_access_token(access_token)
         if not token:
             return self._json_response(
@@ -504,4 +512,4 @@ class OAuth2ProviderController(http.Controller):
         headers, body, status = oauth2_server.create_revocation_response(
             uri, http_method=http_method, body=body, headers=headers
         )
-        return werkzeug.wrappers.BaseResponse(body, status=status, headers=headers)
+        return werkzeug.Response(body, status=status, headers=headers)


### PR DESCRIPTION
**Changes**

- At the token request stage, the `scope` parameter is **optional**. The authorization server **may ignore it entirely or only honor a subset of the values provided**. For this reason, the effective `scope` should not be assumed from the request, but rather treated as **pre-defined and managed by the client’s registered configuration**.
(See [Section 3.3 ("Access Token Scope")](https://tools.ietf.org/html/rfc6749#section-3.3), [Section 4.4.2 ("Access Token Request"](https://tools.ietf.org/html/rfc6749#section-4.4.2))

- `access_token` should be passed in the `Authorization: Bearer ... ` header (See [RFC 6750 Section 2.1](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1))
- Fallbacks: some providers (legacy APIs) still allow `?access_token=...`

- **`BaseResponse`** deprecatied
     - Since odoo 17.0, werkzeug >= 2 is used regardless of python version
     
     **werkzeug 2.0.0**
     > `BaseResponse` will show a deprecation warning and check against `Response` instead. 

     **werkzeug 2.1.0**:
     > Remove `BaseResponse`.

(See [pallets/werkzeug#2360 (comment)](https://github.com/pallets/werkzeug/issues/2360#issuecomment-1081009270))